### PR TITLE
Write logs to keybase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kf5grd/keybasebot
 
-require samhofi.us/x/keybase/v2 v2.0.6
+require samhofi.us/x/keybase/v2 v2.0.8
 
 go 1.15

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-samhofi.us/x/keybase/v2 v2.0.6 h1:gLluTcyjbwckQxSarF1ig2klL4Li7O/THdxsgo1dUvw=
-samhofi.us/x/keybase/v2 v2.0.6/go.mod h1:lJivwhzMSV+WUg+XUbatszStjjFVcuLGl+xcQpqQ5GQ=
+samhofi.us/x/keybase/v2 v2.0.8 h1:hmGZa8v1peHuWBvePI09EXh5vahxbDPqNAXtztLDQzM=
+samhofi.us/x/keybase/v2 v2.0.8/go.mod h1:lJivwhzMSV+WUg+XUbatszStjjFVcuLGl+xcQpqQ5GQ=

--- a/run.go
+++ b/run.go
@@ -4,9 +4,27 @@ import (
 	"github.com/kf5grd/keybasebot/pkg/logr"
 )
 
+// sendLogMessages pulls log messages from the channel and writes them to a Keybase conversation
+func (b *Bot) sendLogMessages(ch chan string) {
+	for {
+		b.KB.SendMessageByConvID(b.LogConv, <-ch)
+	}
+}
+
 // Run starts the bot listening for new messages
 func (b *Bot) Run() error {
-	b.Logger = logr.New(b.LogWriter, b.Debug, b.JSON)
+	// set up logger
+	logWriter := convWriter{
+		// if convID is empty (which is the default) then logs will only be written to stdout,
+		// but if a conversation id is passed here then logs will be written to stdout *and*
+		// this conversation
+		ConvID: b.LogConv,
+		ch:     make(chan string, 100),
+		Writer: b.LogWriter,
+	}
+	go b.sendLogMessages(logWriter.ch)
+	b.Logger = logr.New(logWriter, b.Debug, b.JSON)
+
 	b.registerHandlers()
 	b.AdvertiseCommands()
 	defer b.ClearCommands()

--- a/run.go
+++ b/run.go
@@ -22,7 +22,10 @@ func (b *Bot) Run() error {
 		ch:     make(chan string, 100),
 		Writer: b.LogWriter,
 	}
-	go b.sendLogMessages(logWriter.ch)
+	// only send log messages to Keybase if LogConv is not empty
+	if b.LogConv != "" {
+		go b.sendLogMessages(logWriter.ch)
+	}
 	b.Logger = logr.New(logWriter, b.Debug, b.JSON)
 
 	b.registerHandlers()

--- a/run.go
+++ b/run.go
@@ -4,13 +4,6 @@ import (
 	"github.com/kf5grd/keybasebot/pkg/logr"
 )
 
-// sendLogMessages pulls log messages from the channel and writes them to a Keybase conversation
-func (b *Bot) sendLogMessages(ch chan string) {
-	for {
-		b.KB.SendMessageByConvID(b.LogConv, <-ch)
-	}
-}
-
 // Run starts the bot listening for new messages
 func (b *Bot) Run() error {
 	// set up logger
@@ -19,12 +12,8 @@ func (b *Bot) Run() error {
 		// but if a conversation id is passed here then logs will be written to stdout *and*
 		// this conversation
 		ConvID: b.LogConv,
-		ch:     make(chan string, 100),
 		Writer: b.LogWriter,
-	}
-	// only send log messages to Keybase if LogConv is not empty
-	if b.LogConv != "" {
-		go b.sendLogMessages(logWriter.ch)
+		KB:     b.KB,
 	}
 	b.Logger = logr.New(logWriter, b.Debug, b.JSON)
 


### PR DESCRIPTION
This allows you to specify a keybase conversation id in the bot, and logs will be written to that conversation in addition to the LogWriter